### PR TITLE
added gulp-concat gulp-scss-lint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,246 @@
+# ALL OPTIONS CURRENTLY SET TO FALSE.
+# SET OPTIONS YOU DESIRE TO TRUE.
+
+severity: warning
+
+linters:
+  BangFormat:
+    enabled: false
+    space_before_bang: false
+    space_after_bang: false
+
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
+  BorderZero:
+    enabled: false
+    convention: zero # or `none`
+
+  ChainedClasses:
+    enabled: false
+
+  ColorKeyword:
+    enabled: false
+
+  ColorVariable:
+    enabled: false
+
+  Comment:
+    enabled: false
+    style: silent
+
+  DebugStatement:
+    enabled: false
+
+  DeclarationOrder:
+    enabled: false
+
+  DisableLinterReason:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: false
+
+  ElsePlacement:
+    enabled: false
+    style: same_line # or 'new_line'
+
+  EmptyLineBetweenBlocks:
+    enabled: false
+    ignore_single_line_blocks: false
+
+  EmptyRule:
+    enabled: false
+
+  ExtendDirective:
+    enabled: false
+
+  FinalNewline:
+    enabled: false
+    present: false
+
+  HexLength:
+    enabled: false
+    style: short # or 'long'
+
+  HexNotation:
+    enabled: false
+    style: lowercase # or 'uppercase'
+
+  HexValidation:
+    enabled: false
+
+  IdSelector:
+    enabled: false
+
+  ImportantRule:
+    enabled: false
+
+  ImportPath:
+    enabled: false
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: false
+    allow_non_nested_indentation: false
+    character: space or tab
+    width: 4
+
+  LeadingZero:
+    enabled: false
+    style: exclude_zero # or 'include_zero'
+
+  MergeableSelector:
+    enabled: false
+    force_nesting: false
+
+  NameFormat:
+    enabled: false
+    allow_leading_underscore: false
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+
+  NestingDepth:
+    enabled: false
+    max_depth: 3
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: false
+
+  PrivateNamingConvention:
+    enabled: false
+    prefix: _
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  PropertySortOrder:
+    enabled: false
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: false
+    extra_properties: []
+    disabled_properties: []
+
+  PropertyUnits:
+    enabled: false
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%']                                     # Other
+    properties: {}
+
+  PseudoElement:
+    enabled: false
+
+  QualifyingElement:
+    enabled: false
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: false
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: false
+    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+
+  Shorthand:
+    enabled: false
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: false
+    allow_single_line_rule_sets: false
+
+  SingleLinePerSelector:
+    enabled: false
+
+  SpaceAfterComma:
+    enabled: false
+    style: one_space # or 'no_space', or 'at_least_one_space'
+
+  SpaceAfterPropertyColon:
+    enabled: false
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+
+  SpaceAfterPropertyName:
+    enabled: false
+
+  SpaceAfterVariableColon:
+    enabled: false
+    style: one_space # or 'no_space', 'at_least_one_space' or 'one_space_or_newline'
+
+  SpaceAfterVariableName:
+    enabled: false
+
+  SpaceAroundOperator:
+    enabled: false
+    style: one_space # or 'at_least_one_space', or 'no_space'
+
+  SpaceBeforeBrace:
+    enabled: false
+    style: space # or 'new_line'
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: false
+    spaces: 0
+
+  StringQuotes:
+    enabled: false
+    style: single_quotes # or double_quotes
+
+  TrailingSemicolon:
+    enabled: false
+
+  TrailingWhitespace:
+    enabled: false
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
+    enabled: false
+
+  UnnecessaryMantissa:
+    enabled: false
+
+  UnnecessaryParentReference:
+    enabled: false
+
+  UrlFormat:
+    enabled: false
+
+  UrlQuotes:
+    enabled: false
+
+  VariableForProperty:
+    enabled: false
+    properties: []
+
+  VendorPrefix:
+    enabled: false
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: false
+
+  Compass::*:
+    enabled: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,25 +1,24 @@
 // all the node modules we need
-var gulp = require('gulp');
-var sass = require('gulp-sass');
-var sourcemaps = require('gulp-sourcemaps');
-var jshint = require('gulp-jshint');
-var stylish = require('jshint-stylish');
-var browserSync = require('browser-sync').create();
-
-
-
+var gulp = require('gulp'),
+	sass = require('gulp-sass'),
+	concat = require('gulp-concat'),
+	scsslint = require('gulp-scss-lint'),
+	sourcemaps = require('gulp-sourcemaps'),
+	jshint = require('gulp-jshint'),
+	stylish = require('jshint-stylish'),
+	browserSync = require('browser-sync').create();
 
 // this task takes sass files and compiles them
 gulp.task('sass', function () {
 	return gulp.src('./assets/sass/**/*.scss') // run over these files
 		.pipe(sourcemaps.init()) // make sourcemaps for chrome devtools
+		.pipe(scsslint()) // gulp-scss-lint
 		.pipe(sass().on('error', sass.logError)) // on errors, show them
+		.pipe(concat('main.css')) // gulp-concat
 		.pipe(sourcemaps.write('./')) // put the sourcemaps with the css files
 		.pipe(gulp.dest('./assets/css')) // put the css files here.
         //.pipe(browserSync.stream()); // tell browsersync to send over the changes
 });
-
-
 
 // this task looks through js files for errors
 gulp.task('lint', function () {
@@ -27,8 +26,6 @@ gulp.task('lint', function () {
 		.pipe(jshint()) // error ceck the files
 		.pipe(jshint.reporter('jshint-stylish'/*, {beep: true}*/)); // if there are errors, show them
 });
-
-
 
 gulp.task('default', function() { // running `gulp` runs this task. this task sort of branches off into the others as needed
 


### PR DESCRIPTION
Hey, 

love using this as a starter file for projects... 

Although I was getting frustrated bc it doesn't have a sass linter, and css errors were not being reported so if you made a mistake you would have no idea, maybe a 'gulp-scss-lint' is a good idea? The '.scss-lint.yml' file is the sass lint options. 

Also, sometimes when you save your css/sass the changes do not update via the browser sync... i believe,  though i am not sure,  the 'gulp-concat' fixes this problem.. 

I'm not sure how you setup the 'npm update' so i cant get the (gulp-scss-lint, gulp-concat) to be downloaded with the rest... 


just some ideas, 

Gunnar 
